### PR TITLE
Remove explicit passing of the asyncio loop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ try:
     setup(
         name='dumbot',
         packages=[PKG_DIR],
-        version='1.5.4',
+        version='1.5.5',
         description='dumb async telegram bot for python 3',
         author='Lonami Exo',
         author_email='totufals@hotmail.com',


### PR DESCRIPTION
This has been deprecated for a while and it was completely removed in Python 3.10.